### PR TITLE
fix:-fixes system imagewith the updated android image

### DIFF
--- a/tests/unit_tests/commands/android/testIndex.js
+++ b/tests/unit_tests/commands/android/testIndex.js
@@ -1794,7 +1794,7 @@ describe('test setupAndroid', function() {
 
     assert.deepStrictEqual(binariesCheckedForWorking, ['sdkmanager']);
     assert.strictEqual(cmdlineToolsDownloaded, false);
-    assert.deepStrictEqual(packagesToInstall, [ABI === 'arm64-v8a' ? 'system-images;android-30;google_apis;arm64-v8a' : 'system-images;android-30;google_apis;x86_64', 'emulator']); // emulator updated
+    assert.deepStrictEqual(packagesToInstall, [`system-images;android-30;google_apis;${ABI}`, 'emulator']); // emulator updated
     assert.strictEqual(platformFolderCreated, false);
     assert.strictEqual(buildToolsDownloaded, false);
     assert.strictEqual(avdChecked, true);

--- a/tests/unit_tests/commands/android/testIndex.js
+++ b/tests/unit_tests/commands/android/testIndex.js
@@ -1898,7 +1898,7 @@ describe('test setupAndroid', function() {
 
     assert.deepStrictEqual(binariesCheckedForWorking, ['sdkmanager']);
     assert.strictEqual(cmdlineToolsDownloaded, false);
-    assert.deepStrictEqual(packagesToInstall, [ABI === 'arm64-v8a' ? 'system-images;android-30;google_apis;arm64-v8a' : 'system-images;android-30;google_apis;x86_64', 'emulator']); // emulator updated
+    assert.deepStrictEqual(packagesToInstall, [`system-images;android-30;google_apis;${ABI}`, 'emulator']); // emulator updated
     assert.strictEqual(platformFolderCreated, false);
     assert.strictEqual(buildToolsDownloaded, true);
     assert.strictEqual(avdChecked, true);

--- a/tests/unit_tests/commands/android/testIndex.js
+++ b/tests/unit_tests/commands/android/testIndex.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const mockery = require('mockery');
 const path = require('path');
 const os = require('os');
-import { ABI } from '../../../../src/commands/android/constants'
+import { ABI } from '../../../../src/commands/android/constants';
 
 describe('test showHelp', function() {
   beforeEach(() => {

--- a/tests/unit_tests/commands/android/testIndex.js
+++ b/tests/unit_tests/commands/android/testIndex.js
@@ -1585,7 +1585,7 @@ describe('test setupAndroid', function() {
 
     assert.deepStrictEqual(binariesCheckedForWorking, ['sdkmanager']);
     assert.strictEqual(cmdlineToolsDownloaded, true);
-    assert.deepStrictEqual(packagesInstalled, ['system-images;android-30;google_apis;arm64-v8a', 'emulator']); // emulator updated
+    assert.deepStrictEqual(packagesInstalled, [os.arch() === 'arm64' ? 'system-images;android-30;google_apis;arm64-v8a' : 'system-images;android-30;google_apis;x86_64', 'emulator']); // emulator updated
     assert.strictEqual(platformFolderCreated, true);
     assert.strictEqual(buildToolsDownloaded, true);
     assert.strictEqual(avdChecked, true);
@@ -1793,7 +1793,7 @@ describe('test setupAndroid', function() {
 
     assert.deepStrictEqual(binariesCheckedForWorking, ['sdkmanager']);
     assert.strictEqual(cmdlineToolsDownloaded, false);
-    assert.deepStrictEqual(packagesToInstall, ['system-images;android-30;google_apis;arm64-v8a', 'emulator']); // emulator updated
+    assert.deepStrictEqual(packagesToInstall, [os.arch() === 'arm64' ? 'system-images;android-30;google_apis;arm64-v8a' : 'system-images;android-30;google_apis;x86_64', 'emulator']); // emulator updated
     assert.strictEqual(platformFolderCreated, false);
     assert.strictEqual(buildToolsDownloaded, false);
     assert.strictEqual(avdChecked, true);
@@ -1897,7 +1897,7 @@ describe('test setupAndroid', function() {
 
     assert.deepStrictEqual(binariesCheckedForWorking, ['sdkmanager']);
     assert.strictEqual(cmdlineToolsDownloaded, false);
-    assert.deepStrictEqual(packagesToInstall, ['system-images;android-30;google_apis;arm64-v8a', 'emulator']); // emulator updated
+    assert.deepStrictEqual(packagesToInstall, [os.arch() === 'arm64' ? 'system-images;android-30;google_apis;arm64-v8a' : 'system-images;android-30;google_apis;x86_64', 'emulator']); // emulator updated
     assert.strictEqual(platformFolderCreated, false);
     assert.strictEqual(buildToolsDownloaded, true);
     assert.strictEqual(avdChecked, true);

--- a/tests/unit_tests/commands/android/testIndex.js
+++ b/tests/unit_tests/commands/android/testIndex.js
@@ -1586,7 +1586,7 @@ describe('test setupAndroid', function() {
 
     assert.deepStrictEqual(binariesCheckedForWorking, ['sdkmanager']);
     assert.strictEqual(cmdlineToolsDownloaded, true);
-    assert.deepStrictEqual(packagesInstalled, [ABI === 'arm64-v8a' ? 'system-images;android-30;google_apis;arm64-v8a' : 'system-images;android-30;google_apis;x86_64', 'emulator']); // emulator updated
+    assert.deepStrictEqual(packagesInstalled, [`system-images;android-30;google_apis;${ABI}`, 'emulator']); // emulator updated
     assert.strictEqual(platformFolderCreated, true);
     assert.strictEqual(buildToolsDownloaded, true);
     assert.strictEqual(avdChecked, true);

--- a/tests/unit_tests/commands/android/testIndex.js
+++ b/tests/unit_tests/commands/android/testIndex.js
@@ -1585,7 +1585,7 @@ describe('test setupAndroid', function() {
 
     assert.deepStrictEqual(binariesCheckedForWorking, ['sdkmanager']);
     assert.strictEqual(cmdlineToolsDownloaded, true);
-    assert.deepStrictEqual(packagesInstalled, ['system-images;android-30;google_apis;x86_64', 'emulator']); // emulator updated
+    assert.deepStrictEqual(packagesInstalled, ['system-images;android-30;google_apis;arm64-v8a', 'emulator']); // emulator updated
     assert.strictEqual(platformFolderCreated, true);
     assert.strictEqual(buildToolsDownloaded, true);
     assert.strictEqual(avdChecked, true);
@@ -1793,7 +1793,7 @@ describe('test setupAndroid', function() {
 
     assert.deepStrictEqual(binariesCheckedForWorking, ['sdkmanager']);
     assert.strictEqual(cmdlineToolsDownloaded, false);
-    assert.deepStrictEqual(packagesToInstall, ['system-images;android-30;google_apis;x86_64', 'emulator']); // emulator updated
+    assert.deepStrictEqual(packagesToInstall, ['system-images;android-30;google_apis;arm64-v8a', 'emulator']); // emulator updated
     assert.strictEqual(platformFolderCreated, false);
     assert.strictEqual(buildToolsDownloaded, false);
     assert.strictEqual(avdChecked, true);
@@ -1897,7 +1897,7 @@ describe('test setupAndroid', function() {
 
     assert.deepStrictEqual(binariesCheckedForWorking, ['sdkmanager']);
     assert.strictEqual(cmdlineToolsDownloaded, false);
-    assert.deepStrictEqual(packagesToInstall, ['system-images;android-30;google_apis;x86_64', 'emulator']); // emulator updated
+    assert.deepStrictEqual(packagesToInstall, ['system-images;android-30;google_apis;arm64-v8a', 'emulator']); // emulator updated
     assert.strictEqual(platformFolderCreated, false);
     assert.strictEqual(buildToolsDownloaded, true);
     assert.strictEqual(avdChecked, true);

--- a/tests/unit_tests/commands/android/testIndex.js
+++ b/tests/unit_tests/commands/android/testIndex.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const mockery = require('mockery');
 const path = require('path');
 const os = require('os');
+import { ABI } from '../../../../src/commands/android/constants'
 
 describe('test showHelp', function() {
   beforeEach(() => {
@@ -1585,7 +1586,7 @@ describe('test setupAndroid', function() {
 
     assert.deepStrictEqual(binariesCheckedForWorking, ['sdkmanager']);
     assert.strictEqual(cmdlineToolsDownloaded, true);
-    assert.deepStrictEqual(packagesInstalled, [os.arch() === 'arm64' ? 'system-images;android-30;google_apis;arm64-v8a' : 'system-images;android-30;google_apis;x86_64', 'emulator']); // emulator updated
+    assert.deepStrictEqual(packagesInstalled, [ABI === 'arm64-v8a' ? 'system-images;android-30;google_apis;arm64-v8a' : 'system-images;android-30;google_apis;x86_64', 'emulator']); // emulator updated
     assert.strictEqual(platformFolderCreated, true);
     assert.strictEqual(buildToolsDownloaded, true);
     assert.strictEqual(avdChecked, true);
@@ -1793,7 +1794,7 @@ describe('test setupAndroid', function() {
 
     assert.deepStrictEqual(binariesCheckedForWorking, ['sdkmanager']);
     assert.strictEqual(cmdlineToolsDownloaded, false);
-    assert.deepStrictEqual(packagesToInstall, [os.arch() === 'arm64' ? 'system-images;android-30;google_apis;arm64-v8a' : 'system-images;android-30;google_apis;x86_64', 'emulator']); // emulator updated
+    assert.deepStrictEqual(packagesToInstall, [ABI === 'arm64-v8a' ? 'system-images;android-30;google_apis;arm64-v8a' : 'system-images;android-30;google_apis;x86_64', 'emulator']); // emulator updated
     assert.strictEqual(platformFolderCreated, false);
     assert.strictEqual(buildToolsDownloaded, false);
     assert.strictEqual(avdChecked, true);
@@ -1897,7 +1898,7 @@ describe('test setupAndroid', function() {
 
     assert.deepStrictEqual(binariesCheckedForWorking, ['sdkmanager']);
     assert.strictEqual(cmdlineToolsDownloaded, false);
-    assert.deepStrictEqual(packagesToInstall, [os.arch() === 'arm64' ? 'system-images;android-30;google_apis;arm64-v8a' : 'system-images;android-30;google_apis;x86_64', 'emulator']); // emulator updated
+    assert.deepStrictEqual(packagesToInstall, [ABI === 'arm64-v8a' ? 'system-images;android-30;google_apis;arm64-v8a' : 'system-images;android-30;google_apis;x86_64', 'emulator']); // emulator updated
     assert.strictEqual(platformFolderCreated, false);
     assert.strictEqual(buildToolsDownloaded, true);
     assert.strictEqual(avdChecked, true);


### PR DESCRIPTION
test suits while running `yarn test:unit` had 3 failing tests which was due to the test assertion being compared with old system image of android, this updates the same which is being used and now tests are passing, this changes the image to `arm64-v8a`

Current Behaviour
https://github.com/nightwatchjs/mobile-helper-tool/assets/72331432/d5b8c4c4-8948-4f9f-b770-a1c19439f7df

Updated Behaviour after fixes
 https://github.com/nightwatchjs/mobile-helper-tool/assets/72331432/8e9fad42-8e65-4471-8c30-83529f531426
 
<img width="1512" alt="Screenshot 2024-02-24 at 1 39 35 PM" src="https://github.com/nightwatchjs/mobile-helper-tool/assets/72331432/ba637227-f0f1-422d-9e97-65c20e2bfa16">






