### PR TITLE
refactor:- refactored api error test block

### DIFF
--- a/src/commands/android/utils/common.ts
+++ b/src/commands/android/utils/common.ts
@@ -119,11 +119,10 @@ export const downloadWithProgressBar = async (url: string, dest: string, extract
 export const getLatestVersion = async (browser: 'firefox' | 'chrome'): Promise<string> => {
   if (browser === 'firefox') {
     try {
-      const {data}: AxiosResponse<{tag_name: string}> = await axios('https://api.github.com/repos/mozilla-mobile/fenix/releases/latest');
-
+      const { data }: AxiosResponse<{ tag_name: string }> = await axios('https://api.github.com/repos/mozilla-mobile/fenix/releases/latest');
       return data['tag_name'].slice(1);
-    } catch {
-      return DEFAULT_FIREFOX_VERSION;
+    } catch (error) {
+      throw new Error(`API call failed: ${error}`);
     }
   } else {
     return DEFAULT_CHROME_VERSIONS[1];

--- a/tests/unit_tests/commands/android/testUtilsGetLatestVersion.js
+++ b/tests/unit_tests/commands/android/testUtilsGetLatestVersion.js
@@ -31,16 +31,18 @@ describe('test getAllAvailableOptions', function() {
     assert.strictEqual(version, '105.2.0');
   });
 
-  test('when firefox version not found (error)', async () => {
+  test('should throw an error when the API call fails', async () => {
     nock('https://api.github.com')
       .get('/repos/mozilla-mobile/fenix/releases/latest')
       .reply(502);
 
-    const {getLatestVersion} = require('../../../../src/commands/android/utils/common');
-    const version = await getLatestVersion('firefox');
+    const { getLatestVersion } = require('../../../../src/commands/android/utils/common');
 
-    assert.strictEqual(version, '105.1.0');
+    await assert.rejects(async () => {
+      await getLatestVersion('firefox');
+    }, new Error('API call failed: AxiosError: Request failed with status code 502'));
   });
+
 
   test('when asked for chrome version', async () => {
     const {getLatestVersion} = require('../../../../src/commands/android/utils/common');


### PR DESCRIPTION
currently in the `tests/unit_tests/commands/android/testUtilsGetLatestVersion.js` file, where there is an assertion to check for failing api call, it was wrongly asserted with a `reply(502)` which when fail would just return the default the `FIREFOX_VERSION` this seems wrong and should gracefully rather throw an error. 

updating the same, the tests are working as earlier.

<img width="532" alt="Screenshot 2024-02-24 at 2 22 47 PM" src="https://github.com/nightwatchjs/mobile-helper-tool/assets/72331432/627cde8f-f2cd-4a09-8d1d-d7ae308cc67f">


