### PR TITLE
Added --standalone flag

### DIFF
--- a/src/commands/android/constants.ts
+++ b/src/commands/android/constants.ts
@@ -24,6 +24,10 @@ export const AVAILABLE_OPTIONS: AvailableOptions = {
   appium: {
     alias: [],
     description: 'Make sure the final setup works with Appium out-of-the-box.'
+  },
+  standalone: {
+    alias: [],
+    description: 'Do standalone setup for Android Emulator (no Nightwatch-related requirements will be downloaded).'
   }
 };
 

--- a/src/commands/android/index.ts
+++ b/src/commands/android/index.ts
@@ -415,8 +415,14 @@ export class AndroidSetup {
       }
     }
 
-    if (options.standalone && options.browsers !== true && !configs.browsers) {
+    if (options.standalone && !configs.browsers) {
       configs.browsers = 'none';
+
+      // if just the `--browsers` flag is passed with no argument,
+      // ask the browser question even in the case of standalone.
+      if (options.browsers === true) {
+        delete configs.browsers;
+      }
     }
 
     return configs;

--- a/src/commands/android/index.ts
+++ b/src/commands/android/index.ts
@@ -415,6 +415,10 @@ export class AndroidSetup {
       }
     }
 
+    if (options.standalone && options.browsers !== true && !configs.browsers) {
+      configs.browsers = 'none';
+    }
+
     return configs;
   }
 
@@ -858,12 +862,14 @@ export class AndroidSetup {
 
         // TODO: add major version of Chrome as suffix to chromedriver.
         // Or, check the version of existing chromedriver using --version.
-        Logger.log('Checking if chromedriver is already downloaded...');
-        if (fs.existsSync(chromedriverDownloadPath)) {
-          Logger.log(`  ${colors.green(symbols().ok)} chromedriver already present at '${chromedriverDownloadPath}'\n`);
-        } else {
-          Logger.log(`  ${colors.red(symbols().fail)} chromedriver not found at '${chromedriverDownloadPath}'\n`);
-          downloadChromedriver = true;
+        if (!this.options.standalone) {
+          Logger.log('Checking if chromedriver is already downloaded...');
+          if (fs.existsSync(chromedriverDownloadPath)) {
+            Logger.log(`  ${colors.green(symbols().ok)} chromedriver already present at '${chromedriverDownloadPath}'\n`);
+          } else {
+            Logger.log(`  ${colors.red(symbols().fail)} chromedriver not found at '${chromedriverDownloadPath}'\n`);
+            downloadChromedriver = true;
+          }
         }
       } else if (stdout !== null) {
         Logger.log(`  ${colors.red(symbols().fail)} Chrome browser not found in the AVD.\n`);

--- a/src/commands/android/index.ts
+++ b/src/commands/android/index.ts
@@ -415,6 +415,8 @@ export class AndroidSetup {
       }
     }
 
+    // For standalone mode, don't ask the browser question (set `configs.browsers` to 'none').
+    // But if a user explicitly provides a browser using the `--browsers` flag, use it.
     if (options.standalone && !configs.browsers) {
       configs.browsers = 'none';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export const run = () => {
   try {
     const argv = process.argv.slice(2);
     const {_: args, ...options} = minimist(argv, {
-      boolean: ['install', 'setup', 'help', 'appium'],
+      boolean: ['install', 'setup', 'help', 'appium', 'standalone'],
       alias: {
         help: 'h',
         mode: 'm',

--- a/tests/unit_tests/commands/android/testIndex.js
+++ b/tests/unit_tests/commands/android/testIndex.js
@@ -447,6 +447,7 @@ describe('test getConfigFromOptions', function() {
     configs = androidSetup.getConfigFromOptions({standalone: true, browsers: false});
     assert.deepStrictEqual(configs, {browsers: 'none'});
 
+    // if just `--browsers` option is passed with no argument, ask the browsers question.
     configs = androidSetup.getConfigFromOptions({standalone: true, browsers: true});
     assert.deepStrictEqual(configs, {});
 

--- a/tests/unit_tests/commands/android/testIndex.js
+++ b/tests/unit_tests/commands/android/testIndex.js
@@ -440,6 +440,24 @@ describe('test getConfigFromOptions', function() {
 
     configs = androidSetup.getConfigFromOptions({mode: true, browsers: []});
     assert.deepStrictEqual(configs, {});
+
+    configs = androidSetup.getConfigFromOptions({standalone: true});
+    assert.deepStrictEqual(configs, {browsers: 'none'});
+
+    configs = androidSetup.getConfigFromOptions({standalone: true, browsers: false});
+    assert.deepStrictEqual(configs, {browsers: 'none'});
+
+    configs = androidSetup.getConfigFromOptions({standalone: true, browsers: true});
+    assert.deepStrictEqual(configs, {});
+
+    configs = androidSetup.getConfigFromOptions({standalone: true, browsers: 'chrome'});
+    assert.deepStrictEqual(configs, {browsers: 'chrome'});
+
+    configs = androidSetup.getConfigFromOptions({standalone: true, browsers: 'chrome,firefox'});
+    assert.deepStrictEqual(configs, {browsers: 'both'});
+
+    configs = androidSetup.getConfigFromOptions({standalone: true, browsers: 'brave'});
+    assert.deepStrictEqual(configs, {browsers: 'none'});
   });
 });
 


### PR DESCRIPTION
`--standalone` flag is added to make sure the tool downloads Android SDK to set up emulator. This will ensure that anything related to nightwatch or testing will not be downloaded. 