### PR TITLE
chore: excluded comments inapplicable for standalone mode and bug fix.

### DIFF
--- a/src/commands/android/index.ts
+++ b/src/commands/android/index.ts
@@ -135,7 +135,7 @@ export class AndroidSetup {
 
     this.postSetupInstructions(result, setupConfigs);
 
-    if (setupConfigs.mode !== 'emulator' && !this.options.standalone) {
+    if (!this.options.standalone && setupConfigs.mode !== 'emulator') {
       Logger.log(`${colors.bold('Note:')} Please make sure you have required browsers installed on your real-device before running tests.\n`);
     }
 

--- a/src/commands/android/index.ts
+++ b/src/commands/android/index.ts
@@ -135,7 +135,7 @@ export class AndroidSetup {
 
     this.postSetupInstructions(result, setupConfigs);
 
-    if (setupConfigs.mode !== 'emulator') {
+    if (setupConfigs.mode !== 'emulator' && !this.options.standalone) {
       Logger.log(`${colors.bold('Note:')} Please make sure you have required browsers installed on your real-device before running tests.\n`);
     }
 
@@ -995,7 +995,9 @@ export class AndroidSetup {
       if (result) {
         Logger.log(`${colors.green('Great!')} All the requirements are being met.`);
 
-        if (setupConfigs.mode === 'real') {
+        if (this.options.standalone) {
+          // Logs related to standalone mode to be added here.
+        } else if (setupConfigs.mode === 'real') {
           Logger.log('You can go ahead and run your tests now on your Android device.\n');
         } else {
           Logger.log('You can go ahead and run your tests now on an Android device/emulator.\n');
@@ -1006,7 +1008,10 @@ export class AndroidSetup {
     } else {
       if (result) {
         Logger.log(`${colors.green('Success!')} All requirements are set.`);
-        if (setupConfigs.mode === 'real') {
+
+        if (this.options.standalone) {
+          // Logs related to standalone mode to be added here.
+        } else if (setupConfigs.mode === 'real') {
           Logger.log('You can go ahead and run your tests now on your Android device.\n');
         } else {
           Logger.log('You can go ahead and run your tests now on an Android device/emulator.\n');

--- a/src/commands/ios/constants.ts
+++ b/src/commands/ios/constants.ts
@@ -30,5 +30,9 @@ export const AVAILABLE_OPTIONS: AvailableOptions = {
   appium: {
     alias: [],
     description: 'Make sure the final setup works with Appium out-of-the-box.'
+  },
+  standalone: {
+    alias: [],
+    description: 'Do standalone setup (no Nightwatch-related requirements will be downloaded).'
   }
 };


### PR DESCRIPTION
1, Unnecessary comments related to testing are excluded when running in standalone mode.
2. Added `standalone` as accepted option for ios setup.