### PR TITLE
feat: added scripts and ability to handle subcommands

### DIFF
--- a/src/commands/android/constants.ts
+++ b/src/commands/android/constants.ts
@@ -28,6 +28,10 @@ export const AVAILABLE_OPTIONS: AvailableOptions = {
   standalone: {
     alias: [],
     description: 'Do standalone setup for Android Emulator (no Nightwatch-related requirements will be downloaded).'
+  },
+  wireless: {
+    alias: [],
+    description: 'Connect ADB with wireless connection.'
   }
 };
 

--- a/src/commands/android/constants.ts
+++ b/src/commands/android/constants.ts
@@ -2,7 +2,7 @@ import inquirer from 'inquirer';
 import path from 'path';
 import os from 'os';
 
-import {AvailableOptions, SdkBinary} from './interfaces';
+import {AvailableOptions, AvailableSubcommands, SdkBinary} from './interfaces';
 
 export const AVAILABLE_OPTIONS: AvailableOptions = {
   help: {
@@ -29,11 +29,30 @@ export const AVAILABLE_OPTIONS: AvailableOptions = {
     alias: [],
     description: 'Do standalone setup for Android Emulator (no Nightwatch-related requirements will be downloaded).'
   },
-  wireless: {
-    alias: [],
-    description: 'Connect ADB with wireless connection.'
-  }
 };
+
+export const AVAILABLE_SUBCOMMANDS: AvailableSubcommands = {
+  connect: {
+    description: 'Connect to a device',
+    options: [
+      {
+        name: "wireless",
+        description: "Connect a real device wirelessly",
+      },
+      {
+        name: "avd",
+        description: "Connect to an Android Virtual Device",
+      },
+      {
+        name: "list",
+        description: "List all connected devices",
+      }
+    ]
+  },
+  disconnect: {
+    description: 'Disconnect an AVD or a real device',
+  }
+}
 
 export const NIGHTWATCH_AVD = 'nightwatch-android-11';
 export const DEFAULT_FIREFOX_VERSION = '105.1.0';

--- a/src/commands/android/execute-sdk-commands.ts
+++ b/src/commands/android/execute-sdk-commands.ts
@@ -1,0 +1,102 @@
+import { getAllAvailableOptions, getSdkRootFromEnv, showHelp } from "./utils/common";
+import { getPlatformName } from "../../utils";
+import { Options, Platform } from "./interfaces";
+import * as dotenv from "dotenv";
+import path from "path";
+import colors from "ansi-colors";
+import Logger from "../../logger";
+import {
+  connectAvd,
+  connectWirelessAdb,
+  defaultConnectFlow,
+  disconnectDevice,
+  listRunningDevices,
+} from "./utils/connectDevice";
+import { AVAILABLE_SUBCOMMANDS } from "./constants";
+
+export class SdkCommandExecute {
+  sdkRoot: string;
+  options: Options;
+  subcommand: string;
+  rootDir: string;
+  platform: Platform;
+  androidHomeInGlobalEnv: boolean;
+
+  constructor(subcommand: string, options: Options, rootDir = process.cwd()) {
+    this.sdkRoot = "";
+    this.options = options;
+    this.subcommand = subcommand;
+    this.rootDir = rootDir;
+    this.platform = getPlatformName();
+    this.androidHomeInGlobalEnv = false;
+  }
+
+  async run(): Promise<boolean> {
+    if (!Object.keys(AVAILABLE_SUBCOMMANDS).includes(this.subcommand)) {
+      showHelp([], this.subcommand);
+      
+      return false;
+    } 
+    
+    const unknownOptions = this.getUnknownOptions();
+    if (unknownOptions.length) {
+      showHelp(unknownOptions);
+
+      return false;
+    }
+
+    this.loadEnvFromDotEnv();
+    const sdkRootEnv = getSdkRootFromEnv(this.androidHomeInGlobalEnv, this.rootDir);
+
+    if (!sdkRootEnv) {
+      Logger.log(`Use ${colors.magenta("--standalone")} flag with the main command to setup the Android SDK.`);
+
+      return false;
+    }
+    this.sdkRoot = sdkRootEnv;
+
+    this.executeSdkScript();
+
+    return false;
+  }
+
+  loadEnvFromDotEnv(): void {
+    this.androidHomeInGlobalEnv = "ANDROID_HOME" in process.env;
+
+    dotenv.config({ path: path.join(this.rootDir, ".env") });
+  }
+
+  getUnknownOptions(): string[] {
+    const allAvailableOptions = getAllAvailableOptions();
+    // include all the corresponding options of the subcommand.
+    allAvailableOptions.concat(Object.keys(AVAILABLE_SUBCOMMANDS[this.subcommand].options || []));
+
+    return Object.keys(this.options).filter((option) => !allAvailableOptions.includes(option));
+  }
+
+  async executeSdkScript(): Promise<boolean> {
+    if (this.subcommand === "connect") {
+    // check the corresponding options for the 'connect' subcommand.
+      if (this.options.wireless) {
+        // execute script for wireless adb connection.
+        return await connectWirelessAdb(this.sdkRoot, this.platform);
+      } else if (this.options.avd) {
+        // execute script for connecting to an AVD.
+        return await connectAvd(this.sdkRoot, this.platform);
+      } else if (this.options.list) {
+        // execute script for listing running devices.
+        return listRunningDevices();
+      } else {
+        // execute the default connection flow.
+        return await defaultConnectFlow(this.sdkRoot, this.platform);
+      }
+    }
+
+    if (this.subcommand === "disconnect") {
+    // execute script for disconnecting a device.
+      return await disconnectDevice(this.sdkRoot, this.platform);
+    }
+    
+    return false;
+  }
+}

--- a/src/commands/android/index.ts
+++ b/src/commands/android/index.ts
@@ -26,6 +26,7 @@ import {
 } from './utils/sdk';
 
 import DOWNLOADS from './downloads.json';
+import {connectWirelessAdb} from './utils/adbWirelessConnect';
 
 
 export class AndroidSetup {
@@ -106,6 +107,10 @@ export class AndroidSetup {
 
     this.sdkRoot = sdkRootEnv || await this.getSdkRootFromUser();
     process.env.ANDROID_HOME = this.sdkRoot;
+
+    if (this.options.wireless) {
+      return await connectWirelessAdb(this.sdkRoot, this.platform);
+    }
 
     let result = true;
 

--- a/src/commands/android/interfaces.ts
+++ b/src/commands/android/interfaces.ts
@@ -15,6 +15,18 @@ export interface Options {
   [key: string]: string | string[] | boolean;
 }
 
+export interface AvailableSubcommands {
+  [key: string]: {
+    description: string;
+    options?: {
+      name: string;
+      description: string;
+    }[]
+  }
+}
+
+export type Subcommand = 'connect' | 'disconnect' | undefined;
+
 export type Platform = 'windows' | 'linux' | 'mac';
 
 export interface OtherInfo {

--- a/src/commands/android/utils/adbWirelessConnect.ts
+++ b/src/commands/android/utils/adbWirelessConnect.ts
@@ -1,0 +1,95 @@
+import {Platform} from '../interfaces';
+import {execBinarySync} from './sdk';
+import Logger from '../../../logger';
+import inquirer from 'inquirer';
+import colors from 'ansi-colors';
+import { getBinaryLocation } from './common';
+
+export async function connectWirelessAdb(sdkRoot: string, platform: Platform): Promise<boolean> {
+  try {
+    const adbLocation = getBinaryLocation(sdkRoot, platform, 'adb', true);
+    if (adbLocation === '') {
+      Logger.log(`${colors.red('ADB not found!')} Use ${colors.magenta('--setup')} flag with the main command to setup missing requirements.`);
+
+      return false;
+    }
+
+    Logger.log(`${colors.yellow('Note: This feature is available only for Android 11 and above.\n')}`);
+
+    Logger.log(`${colors.bold('Follow the below steps to connect to your device wirelessly:')}\n`);
+
+    Logger.log(`1.Connect your device to the same network as your computer.`)
+    Logger.log(`${colors.grey('You may connect your device to your computer\'s hotspot')}\n`);
+
+    Logger.log(`2.Enable developer options on your device by going to:`);
+    Logger.log(`${colors.cyan('Settings > About Phone > Build Number')}`);
+    Logger.log(`Tap on build number 7 times until you see the message ${colors.bold('You are now a developer!')}\n`);
+
+    Logger.log(`3.Enable wireless debugging on your device by searching ${colors.bold('wireless debugging')} in the search bar or by going to:`);
+    Logger.log(`${colors.cyan('Settings > Developer Options > Wireless Debugging')}\n`);
+
+    Logger.log(`4.Find the IP address and port number of your device on the wireless debugging screen`);
+    Logger.log(`${colors.grey('IP address and port number are separated by \':\' in the format <ip_address:port>\nwhere IP address comes before \':\' and port number comes after \':\'')}\n`);
+  
+    const deviceIPAnswer = await inquirer.prompt({
+      type: 'input',
+      name: 'deviceIP',
+      message: 'Enter the IP address of your device:'
+    });
+    const deviceIP = deviceIPAnswer.deviceIP;
+
+    const portAnswer = await inquirer.prompt({
+      type: 'input',
+      name: 'port',
+      message: 'Enter the port number:'
+    });
+    const port = portAnswer.port;
+
+    Logger.log();
+    Logger.log(`5.Now find your device's pairing code and pairing port number by going to:`);
+    Logger.log(`${colors.cyan('Settings > Wireless Debugging > Pair device with pairing code')}`);
+    Logger.log(`${colors.grey('Here you will find a pairing code and a')} ${colors.magenta('IP address:port')} ${colors.grey('combination.\nThe port number associated with the IP address is the required pairing port number.\n')}`);
+
+    const pairingCodeAnswer = await inquirer.prompt({
+      type: 'input',
+      name: 'pairingCode',
+      message: 'Enter the pairing code displayed on your device:'
+    });
+    const pairingCode = pairingCodeAnswer.pairingCode;
+
+    const pairingPortAnswer = await inquirer.prompt({
+      type: 'input',
+      name: 'pairingPort',
+      message: 'Enter the pairing port number displayed on your device:'
+    });
+    const pairingPort = pairingPortAnswer.pairingPort;
+
+    Logger.log();
+    Logger.log('Pairing your device with your computer...\n');
+
+    const pairing = execBinarySync(adbLocation, 'adb', platform, `pair ${deviceIP}:${pairingPort} ${pairingCode}`);
+    if (pairing) {
+      Logger.log(`${colors.green('Pairing successful!')} Now connecting to device wirelessly...\n`);
+    } else {
+      Logger.log(`${colors.red('Pairing failed!')} Please try again.`);
+
+      return false;
+    }
+
+    const connecting = execBinarySync(adbLocation, 'adb', platform, `connect ${deviceIP}:${port}`);
+    if (connecting) {
+      Logger.log(colors.green('Connected to device wirelessly.'));
+    } else {
+      Logger.log(`${colors.red('Failed to connect!')} Please try again.`);
+
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    Logger.log('Error connecting to wifi ADB');
+    console.error('Error:', error);
+
+    return false;
+  }
+}

--- a/src/commands/android/utils/common.ts
+++ b/src/commands/android/utils/common.ts
@@ -8,8 +8,10 @@ import path from 'path';
 import which from 'which';
 
 import {symbols} from '../../../utils';
-import {ABI, AVAILABLE_OPTIONS, DEFAULT_CHROME_VERSIONS, DEFAULT_FIREFOX_VERSION, SDK_BINARY_LOCATIONS} from '../constants';
-import {Platform, SdkBinary} from '../interfaces';
+import {ABI, AVAILABLE_OPTIONS, AVAILABLE_SUBCOMMANDS, DEFAULT_CHROME_VERSIONS, DEFAULT_FIREFOX_VERSION, SDK_BINARY_LOCATIONS} from '../constants';
+import { Platform, SdkBinary} from '../interfaces';
+import Logger from '../../../logger';
+import untildify from 'untildify';
 
 export const getAllAvailableOptions = () => {
   const mainOptions = Object.keys(AVAILABLE_OPTIONS);
@@ -152,3 +154,106 @@ export const downloadFirefoxAndroid = async (version: string) => {
 
   return await downloadWithProgressBar(apkDownloadUrl, tempdir);
 };
+
+export function getSdkRootFromEnv(androidHomeInGlobalEnv: boolean, rootDir: string): string {
+  Logger.log('Checking the value of ANDROID_HOME environment variable...');
+
+  const androidHome = process.env.ANDROID_HOME;
+  const fromDotEnv = androidHomeInGlobalEnv ? '' : ' (taken from .env)';
+
+  if (androidHome) {
+    const androidHomeFinal = untildify(androidHome);
+
+    const androidHomeAbsolute = path.resolve(rootDir, androidHomeFinal);
+    if (androidHomeFinal !== androidHomeAbsolute) {
+      Logger.log(`  ${colors.yellow('!')} ANDROID_HOME is set to '${androidHomeFinal}'${fromDotEnv} which is NOT an absolute path.`);
+      Logger.log(`  ${colors.green(symbols().ok)} Considering ANDROID_HOME to be '${androidHomeAbsolute}'\n`);
+
+      return androidHomeAbsolute;
+    }
+
+    Logger.log(`  ${colors.green(symbols().ok)} ANDROID_HOME is set to '${androidHomeFinal}'${fromDotEnv}\n`);
+
+    return androidHomeFinal;
+  }
+
+  if (androidHome === undefined) {
+    Logger.log(
+      `  ${colors.red(symbols().fail)} ANDROID_HOME environment variable is NOT set!\n`
+    );
+  } else {
+    Logger.log(
+      `  ${colors.red(symbols().fail)} ANDROID_HOME is set to '${androidHome}'${fromDotEnv} which is NOT a valid path!\n`
+    );
+  }
+
+  return '';
+}
+
+export function showHelp(unknownOptions: string[], unknownSubcommand?: string ) {
+  if (unknownSubcommand) {
+    Logger.log(colors.red(`unknown subcommand passed: ${unknownSubcommand}\n`));
+  } else if (unknownOptions.length) {
+    Logger.log(colors.red(`unknown option(s) passed: ${unknownOptions.join(', ')}\n`));
+  }
+
+  Logger.log(`Usage: ${colors.cyan('npx @nightwatch/mobile-helper android [options] [subcommand] [subcommand-options]')}`);
+  Logger.log('  Verify if all the requirements are met to run tests on an Android device/emulator.\n');
+
+  Logger.log(`${colors.yellow('Options:')}`);
+
+  const switches = Object.keys(AVAILABLE_OPTIONS).reduce((acc: {[T: string]: string}, key) => {
+    acc[key] = [key].concat(AVAILABLE_OPTIONS[key].alias || [])
+      .map(function(sw) {
+        return (sw.length > 1 ? '--' : '-') + sw;
+      })
+      .join(', ');
+
+    return acc;
+  }, {});
+
+  const longest = (xs: string[]) => Math.max.apply(null, xs.map(x => x.length));
+
+  const switchlen = longest(Object.keys(switches).map(function(s) {
+    return switches[s] || '';
+  }));
+
+  const desclen = longest(Object.keys(AVAILABLE_OPTIONS).map((option) => {
+    return AVAILABLE_OPTIONS[option].description;
+  }));
+
+  Object.keys(AVAILABLE_OPTIONS).forEach(key => {
+    const kswitch = switches[key];
+    let desc = AVAILABLE_OPTIONS[key].description;
+    const spadding = new Array(Math.max(switchlen - kswitch.length + 3, 0)).join('.');
+    const dpadding = new Array(Math.max(desclen - desc.length + 1, 0)).join(' ');
+
+    if (dpadding.length > 0) {
+      desc += dpadding;
+    }
+
+    const prelude = '  ' + (kswitch) + ' ' + colors.grey(spadding);
+
+    Logger.log(prelude + ' ' + colors.grey(desc));
+  });
+
+  Logger.log(`\n${colors.yellow('Subcommands and Subcommand-Options:')}`);
+
+  Object.keys(AVAILABLE_SUBCOMMANDS).forEach(subcommand => {
+    const subcmd = AVAILABLE_SUBCOMMANDS[subcommand];
+    const subcmdOptions = subcmd.options?.map(option => `[--${option.name}]`).join(' ') || '';
+    
+    Logger.log(`  ${colors.cyan(subcommand)} ${subcmdOptions}`);
+    Logger.log(`  ${colors.gray(subcmd.description)}`);
+
+    if (subcmd.options && subcmd.options.length > 0) {
+      const optionLongest = longest(subcmd.options.map(option => `--${option.name}`));
+      subcmd.options.forEach(option => {
+        const optionStr = `--${option.name}`;
+        const optionPadding = new Array(Math.max(optionLongest - optionStr.length + 3, 0)).join('.');
+        Logger.log(`    ${optionStr} ${colors.grey(optionPadding)} ${colors.gray(option.description)}`);
+      });
+    }
+    Logger.log();
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export const run = () => {
   try {
     const argv = process.argv.slice(2);
     const {_: args, ...options} = minimist(argv, {
-      boolean: ['install', 'setup', 'help', 'appium', 'standalone'],
+      boolean: ['install', 'setup', 'help', 'appium', 'standalone', 'wireless'],
       alias: {
         help: 'h',
         mode: 'm',


### PR DESCRIPTION
This PR achieves the following: 
1. The `showHelp` functions now handle subcommands.
2. The options corresponding to subcommands are handled conditionally. For eg. `connect --avd` will execute the script but just `--avd` without the corresponding `connect` subcommand will trigger the `showHelp` function.
3. Added scripts for the following SDK workflows:
     - Connect real device wirelessly.
     - Connect emulator.
     - Show list of currently running devices.
     - Disconnect a currently running device.
  4. Created another class `SdkCommandExecute` to handle the subcommand workflow.
  5. Moved `getSdkRootFromEnv` and `showHelp` to `android/utils/common.ts`

[Screencast from 02-06-24 10:55:14 PM IST.webm](https://github.com/nightwatchjs/mobile-helper-tool/assets/88396544/c144d22f-7f71-4e2f-9436-2e69b93dbecd)
