### PR TITLE
add: display help for subcommands

### DIFF
--- a/src/commands/android/constants.ts
+++ b/src/commands/android/constants.ts
@@ -2,7 +2,7 @@ import inquirer from 'inquirer';
 import path from 'path';
 import os from 'os';
 
-import {AvailableOptions, SdkBinary} from './interfaces';
+import {AvailableOptions, AvailableSubcommands, SdkBinary} from './interfaces';
 
 export const AVAILABLE_OPTIONS: AvailableOptions = {
   help: {
@@ -28,6 +28,18 @@ export const AVAILABLE_OPTIONS: AvailableOptions = {
   standalone: {
     alias: [],
     description: 'Do standalone setup for Android Emulator (no Nightwatch-related requirements will be downloaded).'
+  }
+};
+
+export const AVAILABLE_SUBCOMMANDS: AvailableSubcommands = {
+  connect: {
+    description: 'Connect to a device',
+    options: [
+      {
+        name: 'wireless',
+        description: 'Connect a real device wirelessly'
+      }
+    ]
   }
 };
 

--- a/src/commands/android/index.ts
+++ b/src/commands/android/index.ts
@@ -18,7 +18,8 @@ import {
 import {AndroidSetupResult, Options, OtherInfo, Platform, SdkBinary, SetupConfigs} from './interfaces';
 import {
   downloadFirefoxAndroid, downloadWithProgressBar, getAllAvailableOptions,
-  getBinaryLocation, getBinaryNameForOS, getFirefoxApkName, getLatestVersion
+  getBinaryLocation, getBinaryNameForOS, getFirefoxApkName, getLatestVersion,
+  showSubcommandHelp
 } from './utils/common';
 import {
   downloadAndSetupAndroidSdk, downloadSdkBuildTools, execBinarySync,
@@ -194,6 +195,11 @@ export class AndroidSetup {
 
       Logger.log(prelude + ' ' + colors.grey(desc));
     });
+
+    if (this.options.help) {
+      Logger.log();
+      showSubcommandHelp();
+    }
   }
 
   checkJavaInstallation(): boolean {

--- a/src/commands/android/index.ts
+++ b/src/commands/android/index.ts
@@ -57,9 +57,7 @@ export class AndroidSetup {
       this.showOptionsHelp(unknownOptions);
 
       if (this.options.help) {
-        const subcommandHelp = getSubcommandHelp();
-        Logger.log();
-        Logger.log(subcommandHelp);
+        Logger.log('\n' + getSubcommandHelp());
       }
 
       return this.options.help === true;

--- a/src/commands/android/index.ts
+++ b/src/commands/android/index.ts
@@ -19,7 +19,7 @@ import {AndroidSetupResult, Options, OtherInfo, Platform, SdkBinary, SetupConfig
 import {
   downloadFirefoxAndroid, downloadWithProgressBar, getAllAvailableOptions,
   getBinaryLocation, getBinaryNameForOS, getFirefoxApkName, getLatestVersion,
-  showSubcommandHelp
+  getSubcommandHelp
 } from './utils/common';
 import {
   downloadAndSetupAndroidSdk, downloadSdkBuildTools, execBinarySync,
@@ -54,7 +54,13 @@ export class AndroidSetup {
     const unknownOptions = Object.keys(this.options).filter((option) => !allAvailableOptions.includes(option));
 
     if (this.options.help || unknownOptions.length) {
-      this.showHelp(unknownOptions);
+      this.showOptionsHelp(unknownOptions);
+
+      if (this.options.help) {
+        const subcommandHelp = getSubcommandHelp();
+        Logger.log();
+        Logger.log(subcommandHelp);
+      }
 
       return this.options.help === true;
     }
@@ -151,7 +157,7 @@ export class AndroidSetup {
     };
   }
 
-  showHelp(unknownOptions: string[]) {
+  showOptionsHelp(unknownOptions: string[]) {
     if (unknownOptions.length) {
       Logger.log(colors.red(`unknown option(s) passed: ${unknownOptions.join(', ')}\n`));
     }
@@ -195,11 +201,6 @@ export class AndroidSetup {
 
       Logger.log(prelude + ' ' + colors.grey(desc));
     });
-
-    if (this.options.help) {
-      Logger.log();
-      showSubcommandHelp();
-    }
   }
 
   checkJavaInstallation(): boolean {

--- a/src/commands/android/interfaces.ts
+++ b/src/commands/android/interfaces.ts
@@ -15,6 +15,16 @@ export interface Options {
   [key: string]: string | string[] | boolean;
 }
 
+export interface AvailableSubcommands {
+  [key: string]: {
+    description: string;
+    options: {
+      name: string;
+      description: string;
+    }[];
+  }
+}
+
 export type Platform = 'windows' | 'linux' | 'mac';
 
 export interface OtherInfo {

--- a/src/commands/android/utils/common.ts
+++ b/src/commands/android/utils/common.ts
@@ -8,8 +8,9 @@ import path from 'path';
 import which from 'which';
 
 import {symbols} from '../../../utils';
-import {ABI, AVAILABLE_OPTIONS, DEFAULT_CHROME_VERSIONS, DEFAULT_FIREFOX_VERSION, SDK_BINARY_LOCATIONS} from '../constants';
+import {ABI, AVAILABLE_OPTIONS, AVAILABLE_SUBCOMMANDS, DEFAULT_CHROME_VERSIONS, DEFAULT_FIREFOX_VERSION, SDK_BINARY_LOCATIONS} from '../constants';
 import {Platform, SdkBinary} from '../interfaces';
+import Logger from '../../../logger';
 
 export const getAllAvailableOptions = () => {
   const mainOptions = Object.keys(AVAILABLE_OPTIONS);
@@ -151,4 +152,33 @@ export const downloadFirefoxAndroid = async (version: string) => {
   const apkDownloadUrl = `https://archive.mozilla.org/pub/fenix/releases/${version}/android/fenix-${version}-android-${ABI}/${apkName}`;
 
   return await downloadWithProgressBar(apkDownloadUrl, tempdir);
+};
+
+export const showSubcommandHelp = (unknownSubcommand?: string) => {
+  if (unknownSubcommand) {
+    Logger.log(`${colors.red('unknown subcommand passed:')} ${unknownSubcommand}\n`);
+  }
+  Logger.log(`Usage: ${colors.cyan('npx @nightwatch/mobile-helper android [subcmd] [subcmd-options]')}`);
+  Logger.log('  The following subcommands are used for different operations on Android SDK:\n');
+  Logger.log(`${colors.yellow('Subcommands and Subcommand-Options:')}`);
+
+  const longest = (xs: string[]) => Math.max.apply(null, xs.map(x => x.length));
+
+  Object.keys(AVAILABLE_SUBCOMMANDS).forEach(subcommand => {
+    const subcmd = AVAILABLE_SUBCOMMANDS[subcommand];
+    const subcmdOptions = subcmd.options?.map(option => `[--${option.name}]`).join(' ') || '';
+
+    Logger.log(`  ${colors.cyan(subcommand)} ${subcmdOptions}`);
+    Logger.log(`  ${colors.gray(subcmd.description)}`);
+
+    if (subcmd.options && subcmd.options.length > 0) {
+      const optionLongest = longest(subcmd.options.map(option => `--${option.name}`));
+      subcmd.options.forEach(option => {
+        const optionStr = `--${option.name}`;
+        const optionPadding = new Array(Math.max(optionLongest - optionStr.length + 3, 0)).join('.');
+        Logger.log(`    ${optionStr} ${colors.grey(optionPadding)} ${colors.gray(option.description)}`);
+      });
+    }
+    Logger.log();
+  });
 };

--- a/src/commands/android/utils/common.ts
+++ b/src/commands/android/utils/common.ts
@@ -10,7 +10,6 @@ import which from 'which';
 import {symbols} from '../../../utils';
 import {ABI, AVAILABLE_OPTIONS, AVAILABLE_SUBCOMMANDS, DEFAULT_CHROME_VERSIONS, DEFAULT_FIREFOX_VERSION, SDK_BINARY_LOCATIONS} from '../constants';
 import {Platform, SdkBinary} from '../interfaces';
-import Logger from '../../../logger';
 
 export const getAllAvailableOptions = () => {
   const mainOptions = Object.keys(AVAILABLE_OPTIONS);
@@ -154,13 +153,12 @@ export const downloadFirefoxAndroid = async (version: string) => {
   return await downloadWithProgressBar(apkDownloadUrl, tempdir);
 };
 
-export const showSubcommandHelp = (unknownSubcommand?: string) => {
-  if (unknownSubcommand) {
-    Logger.log(`${colors.red('unknown subcommand passed:')} ${unknownSubcommand}\n`);
-  }
-  Logger.log(`Usage: ${colors.cyan('npx @nightwatch/mobile-helper android [subcmd] [subcmd-options]')}`);
-  Logger.log('  The following subcommands are used for different operations on Android SDK:\n');
-  Logger.log(`${colors.yellow('Subcommands and Subcommand-Options:')}`);
+export const getSubcommandHelp = (): string => {
+  let output = '';
+
+  output += `Usage: ${colors.cyan('npx @nightwatch/mobile-helper android [subcmd] [subcmd-options]')}\n`;
+  output += '  The following subcommands are used for different operations on Android SDK:\n\n';
+  output += `${colors.yellow('Subcommands and Subcommand-Options:')}\n`;
 
   const longest = (xs: string[]) => Math.max.apply(null, xs.map(x => x.length));
 
@@ -168,17 +166,18 @@ export const showSubcommandHelp = (unknownSubcommand?: string) => {
     const subcmd = AVAILABLE_SUBCOMMANDS[subcommand];
     const subcmdOptions = subcmd.options?.map(option => `[--${option.name}]`).join(' ') || '';
 
-    Logger.log(`  ${colors.cyan(subcommand)} ${subcmdOptions}`);
-    Logger.log(`  ${colors.gray(subcmd.description)}`);
+    output += `  ${colors.cyan(subcommand)} ${subcmdOptions}\n`;
+    output += `  ${colors.gray(subcmd.description)}\n`;
 
     if (subcmd.options && subcmd.options.length > 0) {
       const optionLongest = longest(subcmd.options.map(option => `--${option.name}`));
       subcmd.options.forEach(option => {
         const optionStr = `--${option.name}`;
         const optionPadding = new Array(Math.max(optionLongest - optionStr.length + 3, 0)).join('.');
-        Logger.log(`    ${optionStr} ${colors.grey(optionPadding)} ${colors.gray(option.description)}`);
+        output += `    ${optionStr} ${colors.grey(optionPadding)} ${colors.gray(option.description)}\n`;
       });
     }
-    Logger.log();
   });
+
+  return output;
 };

--- a/tests/unit_tests/commands/android/testIndex.js
+++ b/tests/unit_tests/commands/android/testIndex.js
@@ -41,7 +41,7 @@ describe('test showHelp', function() {
 
     const {AndroidSetup} = require('../../../../src/commands/android/index');
     const androidSetup = new AndroidSetup();
-    androidSetup.showHelp(['random']);
+    androidSetup.showOptionsHelp(['random']);
 
     const output = consoleOutput.toString();
     assert.strictEqual(output.includes('unknown option(s) passed: random'), true);
@@ -70,7 +70,7 @@ describe('test showHelp', function() {
 
     const {AndroidSetup} = require('../../../../src/commands/android/index');
     const androidSetup = new AndroidSetup();
-    androidSetup.showHelp([]);
+    androidSetup.showOptionsHelp([]);
 
     const output = consoleOutput.toString();
     assert.strictEqual(output.includes('unknown option(s) passed:'), false);


### PR DESCRIPTION
This PR adds a new `showSubcommandHelp` function that will display help for available subcommands for Android SDK.

![image](https://github.com/nightwatchjs/mobile-helper-tool/assets/88396544/31dd0d81-2387-4d0c-acf8-193be0adaeb8)
