### PR TITLE
feat: install apk

### DIFF
--- a/src/commands/android/subcommands/common.ts
+++ b/src/commands/android/subcommands/common.ts
@@ -1,6 +1,8 @@
 import colors from 'ansi-colors';
 
 import Logger from '../../../logger';
+import {symbols} from '../../../utils';
+import {SdkBinary} from '../interfaces';
 import ADB from '../utils/appium-adb';
 
 const deviceStateWithColor = (state: string) => {
@@ -66,3 +68,10 @@ export async function showConnectedEmulators() {
     return false;
   }
 }
+
+export function showMissingBinaryHelp(binaryName: SdkBinary) {
+  Logger.log(`  ${colors.red(symbols().fail)} ${colors.cyan(binaryName)} binary not found.\n`);
+  Logger.log(`Run: ${colors.cyan('npx @nightwatch/mobile-helper android --standalone')} to setup missing requirements.`);
+  Logger.log(`(Remove the ${colors.gray('--standalone')} flag from the above command if setting up for testing.)\n`);
+}
+

--- a/src/commands/android/subcommands/common.ts
+++ b/src/commands/android/subcommands/common.ts
@@ -1,8 +1,6 @@
 import colors from 'ansi-colors';
 
 import Logger from '../../../logger';
-import {symbols} from '../../../utils';
-import {SdkBinary} from '../interfaces';
 import ADB from '../utils/appium-adb';
 
 const deviceStateWithColor = (state: string) => {
@@ -69,9 +67,7 @@ export async function showConnectedEmulators() {
   }
 }
 
-export function showMissingBinaryHelp(binaryName: SdkBinary) {
-  Logger.log(`  ${colors.red(symbols().fail)} ${colors.cyan(binaryName)} binary not found.\n`);
+export function showMissingRequirementsHelp() {
   Logger.log(`Run: ${colors.cyan('npx @nightwatch/mobile-helper android --standalone')} to setup missing requirements.`);
   Logger.log(`(Remove the ${colors.gray('--standalone')} flag from the above command if setting up for testing.)\n`);
 }
-

--- a/src/commands/android/subcommands/index.ts
+++ b/src/commands/android/subcommands/index.ts
@@ -2,11 +2,12 @@ import colors from 'ansi-colors';
 import * as dotenv from 'dotenv';
 import path from 'path';
 
+import Logger from '../../../logger';
+import {getPlatformName} from '../../../utils';
+import {Options, Platform} from '../interfaces';
 import {checkJavaInstallation, getSdkRootFromEnv} from '../utils/common';
 import {connect} from './connect';
-import {getPlatformName} from '../../../utils';
-import Logger from '../../../logger';
-import {Options, Platform} from '../interfaces';
+import {install} from './install';
 
 export class AndroidSubcommand {
   sdkRoot: string;
@@ -56,6 +57,8 @@ export class AndroidSubcommand {
   async executeSubcommand(): Promise<boolean> {
     if (this.subcommand === 'connect') {
       return await connect(this.options, this.sdkRoot, this.platform);
+    } else if (this.subcommand === 'install') {
+      return await install(this.options, this.sdkRoot, this.platform);
     }
 
     return false;

--- a/src/commands/android/subcommands/install/app.ts
+++ b/src/commands/android/subcommands/install/app.ts
@@ -1,0 +1,111 @@
+import colors from 'ansi-colors';
+import ADB from 'appium-adb';
+import {existsSync} from 'fs';
+import inquirer from 'inquirer';
+import {homedir} from 'os';
+import path from 'path';
+
+import Logger from '../../../../logger';
+import {symbols} from '../../../../utils';
+import {Options, Platform} from '../../interfaces';
+import {getBinaryLocation} from '../../utils/common';
+import {execBinaryAsync} from '../../utils/sdk';
+
+export async function installApp(options: Options, sdkRoot: string, platform: Platform): Promise<boolean> {
+  try {
+    const adbLocation = getBinaryLocation(sdkRoot, platform, 'adb', true);
+    if (!adbLocation) {
+      Logger.log(`  ${colors.red(symbols().fail)} ${colors.cyan('adb')} binary not found.\n`);
+      Logger.log(`Run: ${colors.cyan('npx @nightwatch/mobile-helper android --standalone')} to setup missing requirements.`);
+      Logger.log(`(Remove the ${colors.gray('--standalone')} flag from the above command if setting up for testing.)\n`);
+
+      return false;
+    }
+
+    const adb = await ADB.createADB({allowOfflineDevices: true});
+    const devices = await adb.getConnectedDevices();
+
+    if (!devices.length) {
+      Logger.log(`${colors.red('No device found running.')} Please connect a device to install the APK.`);
+      Logger.log(`Use ${colors.cyan('npx @nightwatch/mobile-helper android connect')} to connect to a device.\n`);
+
+      return true;
+    } else if (devices.length === 1) {
+      // if only one device is connected, then set that device's id to options.deviceId
+      options.deviceId = devices[0].udid;
+    }
+
+    if (options.deviceId && devices.length > 1) {
+      // If device id is passed and there are multiple devices connected then
+      // check if the id is valid. If not then prompt user to select a device.
+      const deviceConnected = devices.find(device => device.udid === options.deviceId);
+      if (!deviceConnected) {
+        Logger.log(`${colors.yellow('Invalid device Id passed!')}\n`);
+
+        options.deviceId = '';
+      }
+    }
+
+    if (!options.deviceId) {
+      // if device id not found, or invalid device id is found, then prompt the user
+      // to select a device from the list of running devices.
+      const deviceAnswer = await inquirer.prompt({
+        type: 'list',
+        name: 'device',
+        message: 'Select the device to install the APK:',
+        choices: devices.map(device => device.udid)
+      });
+      options.deviceId = deviceAnswer.device;
+    }
+
+    if (!options.path) {
+      // if path to APK is not provided, then prompt the user to enter the path.
+      const apkPathAnswer = await inquirer.prompt({
+        type: 'input',
+        name: 'apkPath',
+        message: 'Enter the path to the APK file:'
+      });
+      options.path = apkPathAnswer.apkPath;
+      Logger.log();
+    }
+
+
+    options.path = path.resolve(homedir(), options.path as string);
+    if (!existsSync(options.path)) {
+      Logger.log(`${colors.red('APK file not found!')} Please provide a valid path to the APK file.\n`);
+
+      return false;
+    }
+
+    Logger.log('Installing APK...');
+
+    const installationStatus = await execBinaryAsync(adbLocation, 'adb', platform, `-s ${options.deviceId} install ${options.path}`);
+    if (installationStatus?.includes('Success')) {
+      Logger.log(colors.green('APK installed successfully!\n'));
+
+      return true;
+    }
+
+    handleError(installationStatus);
+
+    return false;
+  } catch (err) {
+    handleError(err);
+
+    return false;
+  }
+}
+
+const handleError = (consoleOutput: any) => {
+  Logger.log(colors.red('Error occured while installing APK'));
+
+  let errorMessage = consoleOutput;
+  if (consoleOutput.includes('INSTALL_FAILED_ALREADY_EXISTS')) {
+    errorMessage = 'APK with the same package name already exists on the device.\n';
+  } else if (consoleOutput.includes('INSTALL_FAILED_OLDER_SDK')) {
+    errorMessage = 'Target installation location (AVD/Real device) has older SDK version than the minimum requirement of the APK.\n';
+  }
+
+  Logger.log(errorMessage);
+};
+

--- a/src/commands/android/subcommands/install/app.ts
+++ b/src/commands/android/subcommands/install/app.ts
@@ -4,17 +4,19 @@ import inquirer from 'inquirer';
 import path from 'path';
 
 import Logger from '../../../../logger';
+import {symbols} from '../../../../utils';
 import {Options, Platform} from '../../interfaces';
 import ADB from '../../utils/appium-adb';
 import {getBinaryLocation} from '../../utils/common';
 import {execBinaryAsync} from '../../utils/sdk';
-import {showMissingBinaryHelp} from '../common';
+import {showMissingRequirementsHelp} from '../common';
 
 export async function installApp(options: Options, sdkRoot: string, platform: Platform): Promise<boolean> {
   try {
     const adbLocation = getBinaryLocation(sdkRoot, platform, 'adb', true);
     if (!adbLocation) {
-      showMissingBinaryHelp('adb');
+      Logger.log(`  ${colors.red(symbols().fail)} ${colors.cyan('adb')} binary not found.\n`);
+      showMissingRequirementsHelp();
 
       return false;
     }
@@ -65,7 +67,7 @@ export async function installApp(options: Options, sdkRoot: string, platform: Pl
 
     options.path = path.resolve(process.cwd(), options.path as string);
     if (!existsSync(options.path)) {
-      Logger.log(`${colors.red('APK file not found!')} Please provide a valid path to the APK file.\n`);
+      Logger.log(`${colors.red('No APK file found at: ' + options.path)}\nPlease provide a valid path to the APK file.\n`);
 
       return false;
     }
@@ -90,16 +92,16 @@ export async function installApp(options: Options, sdkRoot: string, platform: Pl
 }
 
 const handleError = (consoleOutput: any) => {
-  Logger.log(colors.red('Error occured while installing APK'));
+  Logger.log(colors.red('\nError while installing APK:'));
 
   let errorMessage = consoleOutput;
   if (consoleOutput.includes('INSTALL_FAILED_ALREADY_EXISTS')) {
     errorMessage = 'APK with the same package name already exists on the device.\n';
-    errorMessage += 'Please uninstall the app first to install again.\n';
+    errorMessage += colors.reset(`\nPlease uninstall the app first from the device and then install again.\n`);
+    errorMessage += colors.reset(`To uninstall, use: ${colors.cyan('npx @nightwatch/mobile-helper android uninstall --app')}\n`);
   } else if (consoleOutput.includes('INSTALL_FAILED_OLDER_SDK')) {
     errorMessage = 'Target installation location (AVD/Real device) has older SDK version than the minimum requirement of the APK.\n';
   }
 
-  Logger.log(errorMessage);
+  Logger.log(colors.red(errorMessage));
 };
-

--- a/src/commands/android/subcommands/install/index.ts
+++ b/src/commands/android/subcommands/install/index.ts
@@ -1,0 +1,11 @@
+import {Options, Platform} from '../../interfaces';
+import {installApp} from './app';
+
+export async function install(options: Options, sdkRoot: string, platform: Platform): Promise<boolean> {
+  if (options.app) {
+    return await installApp(options, sdkRoot, platform);
+  }
+
+  return false;
+}
+

--- a/src/commands/android/utils/sdk.ts
+++ b/src/commands/android/utils/sdk.ts
@@ -192,7 +192,7 @@ export const execBinaryAsync = (
   binaryName: string,
   platform: Platform,
   args: string
-): Promise<string | null> => {
+): Promise<string> => {
   return new Promise((resolve, reject) => {
     let cmd: string;
     if (binaryLocation === 'PATH') {

--- a/src/commands/android/utils/sdk.ts
+++ b/src/commands/android/utils/sdk.ts
@@ -1,13 +1,13 @@
 import colors from 'ansi-colors';
+import {exec, execSync} from 'child_process';
 import fs from 'fs';
-import path from 'path';
 import {homedir} from 'os';
-import {execSync} from 'child_process';
+import path from 'path';
 
 import {copySync, rmDirSync, symbols} from '../../../utils';
-import {downloadWithProgressBar, getBinaryNameForOS} from './common';
-import {Platform} from '../interfaces';
 import DOWNLOADS from '../downloads.json';
+import {Platform} from '../interfaces';
+import {downloadWithProgressBar, getBinaryNameForOS} from './common';
 
 
 export const getDefaultAndroidSdkRoot = (platform: Platform) => {
@@ -185,6 +185,43 @@ export const execBinarySync = (
 
     return null;
   }
+};
+
+export const execBinaryAsync = (
+  binaryLocation: string,
+  binaryName: string,
+  platform: Platform,
+  args: string
+): Promise<string | null> => {
+  return new Promise((resolve, reject) => {
+    let cmd: string;
+    if (binaryLocation === 'PATH') {
+      const binaryFullName = getBinaryNameForOS(platform, binaryName);
+      cmd = `${binaryFullName} ${args}`;
+    } else {
+      const binaryFullName = path.basename(binaryLocation);
+      const binaryDirPath = path.dirname(binaryLocation);
+
+      if (platform === 'windows') {
+        cmd = `${binaryFullName} ${args}`;
+      } else {
+        cmd = `./${binaryFullName} ${args}`;
+      }
+
+      cmd = `cd ${binaryDirPath} && ${cmd}`;
+    }
+
+    exec(cmd, (error, stdout, stderr) => {
+      if (error) {
+        console.log(
+          `  ${colors.red(symbols().fail)} Failed to run ${colors.cyan(cmd)}`
+        );
+        reject(stderr);
+      } else {
+        resolve(stdout.toString());
+      }
+    });
+  });
 };
 
 export const getBuildToolsAvailableVersions = (buildToolsPath: string): string[] => {


### PR DESCRIPTION
### Description

This PR:

1.  Adds the functionality to install an APK in a target device (AVD / Real device). The feature can be accessed with the new `install` subcommand as shown below:
```bash
npx @nightwatch/mobile-helper android install --app [--path <path_to_apk>] [--deviceId <target_device_id>]
```
2. Adds a new `execBinaryAsync` function instead of reusing the previously present `execBinarySync` function. This was done because synchronous flow cannot catch the error thrown by the `adb install` command. `execBinaryAsync` function runs the command asynchronously allowing us to handle any possible errors.

[Screencast from 29-07-24 03:06:52 PM IST.webm](https://github.com/user-attachments/assets/f89d6527-b82b-4c9a-b377-c0d180e28185)
