### PR TITLE
feat: install avd

### DIFF
--- a/src/commands/android/subcommands/common.ts
+++ b/src/commands/android/subcommands/common.ts
@@ -76,7 +76,7 @@ export async function getInstalledSystemImages(sdkmanagerLocation: string, platf
 }> {
   const stdout = execBinarySync(sdkmanagerLocation, 'sdkmanager', platform, '--list');
   if (!stdout) {
-    Logger.log(`${colors.red('Failed to fetch system images!')} Please try again.`);
+    Logger.log(`\n${colors.red('Failed to fetch system images!')} Please try again.`);
 
     return {
       result: false,

--- a/src/commands/android/subcommands/common.ts
+++ b/src/commands/android/subcommands/common.ts
@@ -1,7 +1,9 @@
 import colors from 'ansi-colors';
 
 import Logger from '../../../logger';
+import {Platform} from '../interfaces';
 import ADB from '../utils/appium-adb';
+import {execBinarySync} from '../utils/sdk';
 
 const deviceStateWithColor = (state: string) => {
   switch (state) {
@@ -66,3 +68,26 @@ export async function showConnectedEmulators() {
     return false;
   }
 }
+
+export async function getInstalledSystemImages(sdkmanagerLocation: string, platform: Platform): Promise<string[]> {
+  const stdout = execBinarySync(sdkmanagerLocation, 'sdkmanager', platform, '--list');
+  if (!stdout) {
+    Logger.log(`${colors.red('Failed to fetch system images!')} Please try again.`);
+
+    return [];
+  }
+  const lines = stdout.split('\n');
+  const installedImages: string[] = [];
+
+  for (const line of lines) {
+    if (line.includes('Available Packages:')) {
+      break;
+    }
+    if (line.includes('system-images')) {
+      installedImages.push(line.split('|')[0].trim());
+    }
+  }
+
+  return installedImages;
+}
+

--- a/src/commands/android/subcommands/common.ts
+++ b/src/commands/android/subcommands/common.ts
@@ -69,12 +69,18 @@ export async function showConnectedEmulators() {
   }
 }
 
-export async function getInstalledSystemImages(sdkmanagerLocation: string, platform: Platform): Promise<string[]> {
+export async function getInstalledSystemImages(sdkmanagerLocation: string, platform: Platform): Promise<{
+  result: boolean,
+  systemImages: string[]
+}> {
   const stdout = execBinarySync(sdkmanagerLocation, 'sdkmanager', platform, '--list');
   if (!stdout) {
     Logger.log(`${colors.red('Failed to fetch system images!')} Please try again.`);
 
-    return [];
+    return {
+      result: false,
+      systemImages: []
+    };
   }
   const lines = stdout.split('\n');
   const installedImages: string[] = [];
@@ -88,6 +94,9 @@ export async function getInstalledSystemImages(sdkmanagerLocation: string, platf
     }
   }
 
-  return installedImages;
+  return {
+    result: true,
+    systemImages: installedImages
+  };
 }
 

--- a/src/commands/android/subcommands/install/avd.ts
+++ b/src/commands/android/subcommands/install/avd.ts
@@ -1,0 +1,134 @@
+import colors from 'ansi-colors';
+import inquirer from 'inquirer';
+
+import Logger from '../../../../logger';
+import {symbols} from '../../../../utils';
+import {Platform} from '../../interfaces';
+import {getBinaryLocation} from '../../utils/common';
+import {execBinaryAsync, execBinarySync} from '../../utils/sdk';
+import {getInstalledSystemImages} from '../common';
+
+type DeviceType = 'Nexus' | 'Pixel' | 'Wear OS' | 'Android TV' | 'Desktop' | 'Others';
+
+const deviceTypesToGrepCommand: Record<DeviceType, string> = {
+  'Nexus': 'Nexus',
+  'Pixel': 'pixel',
+  'Wear OS': 'wear',
+  'Android TV': 'tv',
+  'Desktop': 'desktop',
+  'Others': '-Ev "wear|Nexus|pixel|tv|desktop"'
+};
+
+export async function createAvd(sdkRoot: string, platform: Platform): Promise<boolean> {
+  try {
+    const avdmanagerLocation = getBinaryLocation(sdkRoot, platform, 'avdmanager', true);
+    if (!avdmanagerLocation) {
+      Logger.log(`  ${colors.red(symbols().fail)} ${colors.cyan('avdmanager')} binary not found.\n`);
+      Logger.log(`Run: ${colors.cyan('npx @nightwatch/mobile-helper android --standalone')} to setup missing requirements.`);
+      Logger.log(`(Remove the ${colors.gray('--standalone')} flag from the above command if setting up for testing.)\n`);
+
+      return false;
+    }
+
+    const sdkmanagerLocation = getBinaryLocation(sdkRoot, platform, 'sdkmanager', true);
+    if (!sdkmanagerLocation) {
+      Logger.log(`  ${colors.red(symbols().fail)} ${colors.cyan('sdkmanager')} binary not found.\n`);
+      Logger.log(`Run: ${colors.cyan('npx @nightwatch/mobile-helper android --standalone')} to setup missing requirements.`);
+      Logger.log(`(Remove the ${colors.gray('--standalone')} flag from the above command if setting up for testing.)\n`);
+
+      return false;
+    }
+
+    const avdNameAnswer = await inquirer.prompt({
+      type: 'input',
+      name: 'avdName',
+      message: 'Enter a name for the AVD:'
+    });
+    const avdName = avdNameAnswer.avdName;
+
+    const installedSystemImages: string[] = await getInstalledSystemImages(sdkmanagerLocation, platform);
+    if (!installedSystemImages.length) {
+      return false;
+    }
+
+    const systemImageAnswer = await inquirer.prompt({
+      type: 'list',
+      name: 'systemImage',
+      message: 'Select the system image to use for AVD:',
+      choices: installedSystemImages
+    });
+    const systemImage = systemImageAnswer.systemImage;
+
+    const deviceTypes: DeviceType[] = ['Nexus', 'Pixel', 'Wear OS', 'Android TV', 'Desktop', 'Others'];
+    const deviceTypeAnswer = await inquirer.prompt({
+      type: 'list',
+      name: 'deviceType',
+      message: 'Select the device type for AVD:',
+      choices: deviceTypes
+    });
+    const deviceType = deviceTypeAnswer.deviceType;
+
+    let cmd = `list devices -c | grep ${deviceTypesToGrepCommand[deviceType as DeviceType]}`;
+    const availableDevices = execBinarySync(avdmanagerLocation, 'avdmanager', platform, cmd);
+
+    if (!availableDevices) {
+      Logger.log(`${colors.red('No devices found!')} Please try again.`);
+
+      return false;
+    }
+    const availableDevicesList = availableDevices.split('\n').filter(device => device !== '');
+    const deviceAnswer = await inquirer.prompt({
+      type: 'list',
+      name: 'device',
+      message: 'Select the device profile for AVD:',
+      choices: availableDevicesList
+    });
+    const device = deviceAnswer.device;
+
+    Logger.log();
+    Logger.log('Creating AVD...');
+
+    cmd = `create avd -n '${avdName}' -k '${systemImage}' -d '${device}'`;
+    try {
+      const output = await execBinaryAsync(avdmanagerLocation, 'avdmanager', platform, cmd);
+      if (output?.includes('100% Fetch remote repository')) {
+        Logger.log();
+        Logger.log(`${colors.green('AVD created successfully!')}`);
+
+        return true;
+      }
+    } catch (err) {
+      if (typeof err === 'string') {
+        if (err.includes('already exists')) {
+          // AVD with the same name already exists. Ask user if they want to overwrite it.
+          Logger.log();
+          Logger.log(`${colors.yellow('AVD with the same name already exists!')}\n`);
+          const overwriteAnswer = await inquirer.prompt({
+            type: 'confirm',
+            name: 'overwrite',
+            message: 'Overwrite the existing AVD?'
+          });
+          Logger.log();
+
+          if (overwriteAnswer.overwrite) {
+            cmd += ' --force';
+            const output = await execBinaryAsync(avdmanagerLocation, 'avdmanager', platform, cmd);
+            if (output?.includes('100% Fetch remote repository')) {
+              Logger.log(`${colors.green('AVD created successfully!')}`);
+
+              return true;
+            }
+          }
+        }
+      }
+    }
+
+    return true;
+  } catch (error) {
+    Logger.log(colors.red('Error occured while creating AVD.'));
+    console.error(error);
+
+    return false;
+  }
+}
+

--- a/src/commands/android/subcommands/install/avd.ts
+++ b/src/commands/android/subcommands/install/avd.ts
@@ -39,7 +39,7 @@ export async function createAvd(sdkRoot: string, platform: Platform): Promise<bo
       name: 'avdName',
       message: 'Enter a name for the AVD:'
     });
-    const avdName = avdNameAnswer.avdName ? avdNameAnswer.avdName : 'my_avd';
+    const avdName = avdNameAnswer.avdName || 'my_avd';
 
     const installedSystemImages = await getInstalledSystemImages(sdkmanagerLocation, platform);
     if (!installedSystemImages.result) {
@@ -92,11 +92,11 @@ export async function createAvd(sdkRoot: string, platform: Platform): Promise<bo
     let createAVDStatus = false;
 
     try {
-      createAVDStatus = await createAVD(cmd, avdmanagerLocation, platform, avdName);
+      createAVDStatus = await executeCreateAvdCommand(cmd, avdmanagerLocation, platform, avdName);
     } catch (err) {
       if (typeof err === 'string' && err.includes('already exists')) {
         // AVD with the same name already exists. Ask user if they want to overwrite it.
-        Logger.log(`${colors.yellow('AVD with the same name already exists!')}\n`);
+        Logger.log(`\n${colors.yellow('AVD with the same name already exists!')}\n`);
         const overwriteAnswer = await inquirer.prompt({
           type: 'confirm',
           name: 'overwrite',
@@ -106,7 +106,7 @@ export async function createAvd(sdkRoot: string, platform: Platform): Promise<bo
 
         if (overwriteAnswer.overwrite) {
           cmd += ' --force';
-          createAVDStatus = await createAVD(cmd, avdmanagerLocation, platform, avdName);
+          createAVDStatus = await executeCreateAvdCommand(cmd, avdmanagerLocation, platform, avdName);
         }
       } else {
         handleError(err);
@@ -121,7 +121,7 @@ export async function createAvd(sdkRoot: string, platform: Platform): Promise<bo
   }
 }
 
-async function createAVD(cmd: string, avdmanagerLocation: string, platform: Platform, avdName: string): Promise<boolean> {
+async function executeCreateAvdCommand(cmd: string, avdmanagerLocation: string, platform: Platform, avdName: string): Promise<boolean> {
   const output = await execBinaryAsync(avdmanagerLocation, 'avdmanager', platform, cmd);
 
   if (output?.includes('100% Fetch remote repository')) {
@@ -139,7 +139,7 @@ async function createAVD(cmd: string, avdmanagerLocation: string, platform: Plat
 }
 
 function handleError(err: any) {
-  Logger.log(colors.red('Error occured while creating AVD!\n'));
+  Logger.log(colors.red('\nError occurred while creating AVD!'));
   console.error(err);
 }
 

--- a/src/commands/android/subcommands/install/avd.ts
+++ b/src/commands/android/subcommands/install/avd.ts
@@ -44,9 +44,10 @@ export async function createAvd(sdkRoot: string, platform: Platform): Promise<bo
     const installedSystemImages = await getInstalledSystemImages(sdkmanagerLocation, platform);
     if (!installedSystemImages.result) {
       return false;
-    } else if (!installedSystemImages.systemImages.length) {
-      Logger.log(colors.red('No system image is installed!'));
-      Logger.log(`Run ${colors.cyan('npx @nightwatch/mobile-helper android install --system-image')} to install system images.`);
+    }
+    if (!installedSystemImages.systemImages.length) {
+      Logger.log(colors.red('\nNo installed system images were found!'));
+      Logger.log(`Run: ${colors.cyan('npx @nightwatch/mobile-helper android install --system-image')} to install a new system image.`);
 
       return false;
     }

--- a/src/commands/android/subcommands/install/avd.ts
+++ b/src/commands/android/subcommands/install/avd.ts
@@ -41,8 +41,13 @@ export async function createAvd(sdkRoot: string, platform: Platform): Promise<bo
     });
     const avdName = avdNameAnswer.avdName;
 
-    const installedSystemImages: string[] = await getInstalledSystemImages(sdkmanagerLocation, platform);
-    if (!installedSystemImages.length) {
+    const installedSystemImages = await getInstalledSystemImages(sdkmanagerLocation, platform);
+    if (!installedSystemImages.result) {
+      return false;
+    } else if (!installedSystemImages.systemImages.length) {
+      Logger.log(colors.red('No system image is installed!'));
+      Logger.log(`Run ${colors.cyan('npx @nightwatch/mobile-helper android install --system-image')} to install system images.`);
+
       return false;
     }
 
@@ -50,7 +55,7 @@ export async function createAvd(sdkRoot: string, platform: Platform): Promise<bo
       type: 'list',
       name: 'systemImage',
       message: 'Select the system image to use for AVD:',
-      choices: installedSystemImages
+      choices: installedSystemImages.systemImages
     });
     const systemImage = systemImageAnswer.systemImage;
 

--- a/src/commands/android/subcommands/install/avd.ts
+++ b/src/commands/android/subcommands/install/avd.ts
@@ -2,11 +2,10 @@ import colors from 'ansi-colors';
 import inquirer from 'inquirer';
 
 import Logger from '../../../../logger';
-import {symbols} from '../../../../utils';
 import {Platform} from '../../interfaces';
 import {getBinaryLocation} from '../../utils/common';
 import {execBinaryAsync, execBinarySync} from '../../utils/sdk';
-import {getInstalledSystemImages} from '../common';
+import {getInstalledSystemImages, showMissingBinaryHelp} from '../common';
 
 type DeviceType = 'Nexus' | 'Pixel' | 'Wear OS' | 'Android TV' | 'Desktop' | 'Others';
 
@@ -23,18 +22,14 @@ export async function createAvd(sdkRoot: string, platform: Platform): Promise<bo
   try {
     const avdmanagerLocation = getBinaryLocation(sdkRoot, platform, 'avdmanager', true);
     if (!avdmanagerLocation) {
-      Logger.log(`  ${colors.red(symbols().fail)} ${colors.cyan('avdmanager')} binary not found.\n`);
-      Logger.log(`Run: ${colors.cyan('npx @nightwatch/mobile-helper android --standalone')} to setup missing requirements.`);
-      Logger.log(`(Remove the ${colors.gray('--standalone')} flag from the above command if setting up for testing.)\n`);
+      showMissingBinaryHelp('avdmanager');
 
       return false;
     }
 
     const sdkmanagerLocation = getBinaryLocation(sdkRoot, platform, 'sdkmanager', true);
     if (!sdkmanagerLocation) {
-      Logger.log(`  ${colors.red(symbols().fail)} ${colors.cyan('sdkmanager')} binary not found.\n`);
-      Logger.log(`Run: ${colors.cyan('npx @nightwatch/mobile-helper android --standalone')} to setup missing requirements.`);
-      Logger.log(`(Remove the ${colors.gray('--standalone')} flag from the above command if setting up for testing.)\n`);
+      showMissingBinaryHelp('sdkmanager');
 
       return false;
     }

--- a/src/commands/android/subcommands/install/index.ts
+++ b/src/commands/android/subcommands/install/index.ts
@@ -1,9 +1,12 @@
 import {Options, Platform} from '../../interfaces';
 import {installApp} from './app';
+import {createAvd} from './avd';
 
 export async function install(options: Options, sdkRoot: string, platform: Platform): Promise<boolean> {
   if (options.app) {
     return await installApp(options, sdkRoot, platform);
+  } else if (options.avd) {
+    return await createAvd(sdkRoot, platform);
   }
 
   return false;


### PR DESCRIPTION
### Description 
This PR 

1. Adds the support to create a new AVD using the installed system-images with the following command: 

```bash
npx @nightwatch/mobile-helper android install --avd
``` 

2. Adds a utility function called `getInstalledSystemImages`which fetches a list of installed system images in the computer.

[Screencast from 31-07-24 09:35:23 PM IST.webm](https://github.com/user-attachments/assets/d7c4d772-29d8-4c16-a5da-6c5c4de2f3f4)
