### PR TITLE
feat: list installed avd and connected devices

### DIFF
--- a/src/commands/android/constants.ts
+++ b/src/commands/android/constants.ts
@@ -41,6 +41,17 @@ export const AVAILABLE_SUBCOMMANDS: AvailableSubcommands = {
         description: 'Connect a real device wirelessly'
       }
     ]
+  },
+  list: {
+    description: 'List connected devices or installed AVDs',
+    flags: [{
+      name: 'device',
+      description: 'List connected devices (real devices and AVDs)'
+    },
+    {
+      name: 'avd',
+      description: 'List installed AVDs'
+    }]
   }
 };
 

--- a/src/commands/android/subcommands/index.ts
+++ b/src/commands/android/subcommands/index.ts
@@ -6,9 +6,10 @@ import Logger from '../../../logger';
 import {getPlatformName} from '../../../utils';
 import {Options, Platform} from '../interfaces';
 import {checkJavaInstallation, getSdkRootFromEnv} from '../utils/common';
-import {showHelp} from './help';
 import {connect} from './connect';
+import {showHelp} from './help';
 import {install} from './install';
+import {list} from './list';
 
 export class AndroidSubcommand {
   sdkRoot: string;
@@ -65,6 +66,8 @@ export class AndroidSubcommand {
       return await connect(this.options, this.sdkRoot, this.platform);
     } else if (this.subcommand === 'install') {
       return await install(this.options, this.sdkRoot, this.platform);
+    } else if (this.subcommand === 'list') {
+      return await list(this.options, this.sdkRoot, this.platform);
     }
 
     return false;

--- a/src/commands/android/subcommands/list/avd.ts
+++ b/src/commands/android/subcommands/list/avd.ts
@@ -1,0 +1,35 @@
+import colors from 'ansi-colors';
+
+import Logger from '../../../../logger';
+import {Platform} from '../../interfaces';
+import {getBinaryLocation} from '../../utils/common';
+import {execBinarySync} from '../../utils/sdk';
+import {showMissingBinaryHelp} from '../common';
+
+export async function listInstalledAVDs(sdkRoot: string, platform: Platform): Promise<boolean> {
+  try {
+    const avdmanagerLocation = getBinaryLocation(sdkRoot, platform, 'avdmanager', true);
+    if (!avdmanagerLocation) {
+      showMissingBinaryHelp('avdmanager');
+
+      return false;
+    }
+
+    const installedAVDs = execBinarySync(avdmanagerLocation, 'avd', platform, 'list avd');
+    if (!installedAVDs) {
+      Logger.log(`\n${colors.red('Failed to list installed AVDs!')} Please try again.`);
+
+      return false;
+    }
+
+    Logger.log(installedAVDs);
+
+    return true;
+  } catch (err) {
+    Logger.log(colors.red('Error occured while listing installed AVDs.'));
+    console.error(err);
+
+    return false;
+  }
+}
+

--- a/src/commands/android/subcommands/list/avd.ts
+++ b/src/commands/android/subcommands/list/avd.ts
@@ -22,14 +22,17 @@ export async function listInstalledAVDs(sdkRoot: string, platform: Platform): Pr
       return false;
     }
 
-    Logger.log(installedAVDs);
+    if (installedAVDs.split('\n').length < 3) {
+      Logger.log(colors.red('No installed AVDs found!'));
+    } else {
+      Logger.log(installedAVDs);
+    }
 
     return true;
   } catch (err) {
-    Logger.log(colors.red('Error occured while listing installed AVDs.'));
+    Logger.log(colors.red('Error occurred while listing installed AVDs.'));
     console.error(err);
 
     return false;
   }
 }
-

--- a/src/commands/android/subcommands/list/device.ts
+++ b/src/commands/android/subcommands/list/device.ts
@@ -1,0 +1,31 @@
+import colors from 'ansi-colors';
+
+import Logger from '../../../../logger';
+import {Platform} from '../../interfaces';
+import ADB from '../../utils/appium-adb';
+import {getBinaryLocation} from '../../utils/common';
+import {showConnectedEmulators, showConnectedRealDevices, showMissingBinaryHelp} from '../common';
+
+export async function listConnectedDevices(sdkRoot: string, platform: Platform): Promise<boolean> {
+  const adbLocation = getBinaryLocation(sdkRoot, platform, 'adb', true);
+  if (adbLocation === '') {
+    showMissingBinaryHelp('adb');
+
+    return false;
+  }
+
+  const adb = await ADB.createADB({allowOfflineDevices: true});
+  const devices = await adb.getConnectedDevices();
+
+  if (!devices.length) {
+    Logger.log(colors.yellow('No connected devices found.\n'));
+
+    return true;
+  }
+
+  await showConnectedRealDevices();
+  await showConnectedEmulators();
+
+  return true;
+}
+

--- a/src/commands/android/subcommands/list/device.ts
+++ b/src/commands/android/subcommands/list/device.ts
@@ -28,4 +28,3 @@ export async function listConnectedDevices(sdkRoot: string, platform: Platform):
 
   return true;
 }
-

--- a/src/commands/android/subcommands/list/index.ts
+++ b/src/commands/android/subcommands/list/index.ts
@@ -1,0 +1,45 @@
+import inquirer from 'inquirer';
+
+import Logger from '../../../../logger';
+import {Options, Platform} from '../../interfaces';
+import {listInstalledAVDs} from './avd';
+import {listConnectedDevices} from './device';
+import {verifyOptions} from '../common';
+
+export async function list(options: Options, sdkRoot: string, platform: Platform): Promise<boolean> {
+  const optionsVerified = verifyOptions('list', options);
+  if (!optionsVerified) {
+    return false;
+  }
+
+  const subcommandFlag = optionsVerified.subcommandFlag;
+  if (subcommandFlag === '') {
+    await flagsPrompt(options);
+  }
+
+  if (options.avd) {
+    return await listInstalledAVDs(sdkRoot, platform);
+  } else if (options.device) {
+    return await listConnectedDevices(sdkRoot, platform);
+  }
+
+  return false;
+}
+
+async function flagsPrompt(options: Options) {
+  const flagAnswer = await inquirer.prompt({
+    type: 'list',
+    name: 'flag',
+    message: 'Select what do you want to list:',
+    choices: ['Connected devices', 'Installed AVDs']
+  });
+
+  const flag = flagAnswer.flag;
+  if (flag === 'Connected devices') {
+    options.device = true;
+  } else if (flag === 'Installed AVDs') {
+    options.avd = true;
+  }
+  Logger.log();
+}
+

--- a/src/commands/android/subcommands/list/index.ts
+++ b/src/commands/android/subcommands/list/index.ts
@@ -2,9 +2,9 @@ import inquirer from 'inquirer';
 
 import Logger from '../../../../logger';
 import {Options, Platform} from '../../interfaces';
+import {verifyOptions} from '../common';
 import {listInstalledAVDs} from './avd';
 import {listConnectedDevices} from './device';
-import {verifyOptions} from '../common';
 
 export async function list(options: Options, sdkRoot: string, platform: Platform): Promise<boolean> {
   const optionsVerified = verifyOptions('list', options);
@@ -12,34 +12,33 @@ export async function list(options: Options, sdkRoot: string, platform: Platform
     return false;
   }
 
-  const subcommandFlag = optionsVerified.subcommandFlag;
+  let subcommandFlag = optionsVerified.subcommandFlag;
   if (subcommandFlag === '') {
-    await flagsPrompt(options);
+    subcommandFlag = await promptForFlag();
   }
 
-  if (options.avd) {
+  if (subcommandFlag === 'avd') {
     return await listInstalledAVDs(sdkRoot, platform);
-  } else if (options.device) {
+  } else if (subcommandFlag === 'device') {
     return await listConnectedDevices(sdkRoot, platform);
   }
 
   return false;
 }
 
-async function flagsPrompt(options: Options) {
+async function promptForFlag(): Promise<string> {
   const flagAnswer = await inquirer.prompt({
     type: 'list',
     name: 'flag',
     message: 'Select what do you want to list:',
     choices: ['Connected devices', 'Installed AVDs']
   });
+  Logger.log();
 
   const flag = flagAnswer.flag;
   if (flag === 'Connected devices') {
-    options.device = true;
-  } else if (flag === 'Installed AVDs') {
-    options.avd = true;
+    return 'device';
   }
-  Logger.log();
-}
 
+  return 'avd';
+}


### PR DESCRIPTION
### Description

This PR adds the functionality to list all the installed AVDs and running devices.

Commands used:

```bash
# list installed avds
npx @nightwatch/mobile-helper android list --avd

# list connected devices
npx @nightwatch/mobile-helper android list --device
```
![Screenshot from 2024-08-20 21-11-43](https://github.com/user-attachments/assets/3644243c-4af0-4116-8d8f-4ae678adb561)

![Screenshot from 2024-08-20 21-13-21](https://github.com/user-attachments/assets/0b8d640b-717a-4409-a9f0-ba5b786b3cb5)
