### PR TITLE
Add default flow for the `install` subcommand

### DIFF
--- a/src/commands/android/constants.ts
+++ b/src/commands/android/constants.ts
@@ -41,6 +41,33 @@ export const AVAILABLE_SUBCOMMANDS: AvailableSubcommands = {
         description: 'Connect a real device wirelessly'
       }
     ]
+  },
+  install: {
+    description: 'Install APK or AVD on a device',
+    flags: [
+      {
+        name: 'avd',
+        description: 'Create an Android Virtual Device'
+      },
+      {
+        name: 'app',
+        description: 'Install an APK on the device',
+        cliConfigs: [
+          {
+            name: 'path',
+            alias: ['p'],
+            description: 'Path to the APK file',
+            usageHelp: 'path_to_apk'
+          },
+          {
+            name: 'deviceId',
+            alias: ['s'],
+            description: 'Id of the device to install the APK',
+            usageHelp: 'device_id'
+          }
+        ]
+      }
+    ]
   }
 };
 

--- a/src/commands/android/subcommands/install/app.ts
+++ b/src/commands/android/subcommands/install/app.ts
@@ -95,7 +95,7 @@ const handleError = (consoleOutput: any) => {
   let errorMessage = consoleOutput;
   if (consoleOutput.includes('INSTALL_FAILED_ALREADY_EXISTS')) {
     errorMessage = 'APK with the same package name already exists on the device.\n';
-    errorMessage += colors.reset(`\nPlease uninstall the app first from the device and then install again.\n`);
+    errorMessage += colors.reset('\nPlease uninstall the app first from the device and then install again.\n');
     errorMessage += colors.reset(`To uninstall, use: ${colors.cyan('npx @nightwatch/mobile-helper android uninstall --app')}\n`);
   } else if (consoleOutput.includes('INSTALL_FAILED_OLDER_SDK')) {
     errorMessage = 'Target installation location (AVD/Real device) has older SDK version than the minimum requirement of the APK.\n';

--- a/src/commands/android/subcommands/install/index.ts
+++ b/src/commands/android/subcommands/install/index.ts
@@ -12,34 +12,34 @@ export async function install(options: Options, sdkRoot: string, platform: Platf
     return false;
   }
 
-  const subcommandFlag = optionsVerified.subcommandFlag;
+  let subcommandFlag = optionsVerified.subcommandFlag;
   if (subcommandFlag === '') {
-    await flagsPrompt(options);
+    subcommandFlag = await promptForFlag();
   }
 
-  if (options.app) {
+  if (subcommandFlag === 'app') {
     return await installApp(options, sdkRoot, platform);
-  } else if (options.avd) {
+  } else if (subcommandFlag === 'avd') {
     return await createAvd(sdkRoot, platform);
   }
 
   return false;
 }
 
-async function flagsPrompt(options: Options) {
+async function promptForFlag(): Promise<string> {
   const flagAnswer = await inquirer.prompt({
     type: 'list',
     name: 'flag',
     message: 'Select what do you want to install:',
     choices: ['APK', 'AVD']
   });
+  Logger.log();
 
   const flag = flagAnswer.flag;
   if (flag === 'APK') {
-    options.app = true;
-  } else if (flag === 'AVD') {
-    options.avd = true;
+    return 'app';
   }
-  Logger.log();
+
+  return 'avd';
 }
 

--- a/src/commands/android/subcommands/install/index.ts
+++ b/src/commands/android/subcommands/install/index.ts
@@ -1,8 +1,22 @@
+import inquirer from 'inquirer';
+
+import Logger from '../../../../logger';
 import {Options, Platform} from '../../interfaces';
+import {verifyOptions} from '../common';
 import {installApp} from './app';
 import {createAvd} from './avd';
 
 export async function install(options: Options, sdkRoot: string, platform: Platform): Promise<boolean> {
+  const optionsVerified = verifyOptions('install', options);
+  if (!optionsVerified) {
+    return false;
+  }
+
+  const subcommandFlag = optionsVerified.subcommandFlag;
+  if (subcommandFlag === '') {
+    await flagsPrompt(options);
+  }
+
   if (options.app) {
     return await installApp(options, sdkRoot, platform);
   } else if (options.avd) {
@@ -10,5 +24,22 @@ export async function install(options: Options, sdkRoot: string, platform: Platf
   }
 
   return false;
+}
+
+async function flagsPrompt(options: Options) {
+  const flagAnswer = await inquirer.prompt({
+    type: 'list',
+    name: 'flag',
+    message: 'Select what do you want to install:',
+    choices: ['APK', 'AVD']
+  });
+
+  const flag = flagAnswer.flag;
+  if (flag === 'APK') {
+    options.app = true;
+  } else if (flag === 'AVD') {
+    options.avd = true;
+  }
+  Logger.log();
 }
 


### PR DESCRIPTION
This PR 
- Adds details for the `install` subcommand in the `AVAILABLE_SUBCOMMANDS` object.
- Adds default flow for the `install` subcommand when no flag is passed.
- Fixes a minor eslint error.