### PR TITLE
Updated readme for android subcommand workflows

### DIFF
--- a/docs/subcommands/connect.md
+++ b/docs/subcommands/connect.md
@@ -13,3 +13,19 @@ Run the below command to connect to a real device wirelessly:
 ```sh
 npx @nightwatch/mobile-helper android connect --wireless
 ```
+
+### 2. Launch an Android Virtual Device
+
+Run the below command to launch an AVD:
+```sh
+npx @nightwatch/mobile-helper android connect --emulator
+
+# with configs
+npx @nightwatch/mobile-helper android connect --emulator [--avd <avd_name>]
+```
+
+**Configs**
+
+| Config             | Description               |
+| ------------------ | ------------------------- |
+| --avd <avd_name>   | Name of the AVD to launch |

--- a/docs/subcommands/install.md
+++ b/docs/subcommands/install.md
@@ -30,3 +30,10 @@ Run the below command to create a new AVD:
 ```sh
 npx @nightwatch/mobile-helper android install --avd
 ```
+
+### 3. Install a system image
+
+Run the below command to install a new system image:
+```sh
+npx @nightwatch/mobile-helper android install --system-image
+```

--- a/docs/subcommands/uninstall.md
+++ b/docs/subcommands/uninstall.md
@@ -13,3 +13,26 @@ Run the below command to delete an AVD:
 ```sh
 npx @nightwatch/mobile-helper android uninstall --avd
 ```
+
+### 2. Uninstall a system image
+
+Run the below command to uninstall a system image:
+```sh
+npx @nightwatch/mobile-helper android uninstall --system-image
+```
+
+### 3. Uninstall an app 
+
+Run the below command to uninstall an app from a real device or an AVD:
+```sh
+npx @nightwatch/mobile-helper android uninstall --app
+
+# with configs
+npx @nightwatch/mobile-helper android uninstall --app [--deviceId <device_id>]
+```
+
+**Configs**
+
+| Config                         | Description                                       |
+| ------------------------------ | ------------------------------------------------- |
+| --deviceId \| -s <device_id>   | Id of the device to uninstall the app from        |


### PR DESCRIPTION
Added documentation for the following workflows in the readme:
1. Launch an Android Virtual Device
2. Install a system image
3. Uninstall a system image
4. Uninstall an app 